### PR TITLE
fix($drag): improve caching of mouse position

### DIFF
--- a/src/draggable.js
+++ b/src/draggable.js
@@ -63,7 +63,9 @@ var $dragProvider = function() {
         currentDrag = self;
 
         self.cssDisplay = self.element.css('display');
-        self.cssPosition = self.element.css("position");
+        if (!self.hanging) {
+          self.cssPosition = self.element.css("position");
+        }
 
         self.offset = self.positionAbs = DOM.offset(self.element);
 
@@ -76,10 +78,15 @@ var $dragProvider = function() {
           },
         });
 
+        self.lastMouseY = event.pageY;
+        self.lastMouseX = event.pageX;
+
         self.startEvent = event;
-        self.originalPosition = self.element.css('position');
+
         self.element.css({
-          position: 'absolute'
+          position: 'absolute',
+          left: self.offset.left,
+          top: self.offset.top
         });
 
         $document.on("mousemove", self.drag);
@@ -108,8 +115,8 @@ var $dragProvider = function() {
         var style = self.element.prop('style');
 
         var position = {
-          top: event.clientY,
-          left: event.clientX
+          top: event.pageY,
+          left: event.pageX
         },
         x = style.left || 0, y = style.top || 0,  nx, ny;
 

--- a/src/droppable.js
+++ b/src/droppable.js
@@ -10,7 +10,7 @@ var droppableDirective = ['$drop', function($drop) {
 }];
 
 var $dropProvider = function() {
-  this.$get = ['$document', function($document) {
+  this.$get = ['$document', '$rootScope', function($document, $rootScope) {
     var $drop = {
       isDroppable: function(element) {
         return !!$drag.droppable(element);
@@ -74,7 +74,7 @@ var $dropProvider = function() {
 
         element = document.elementFromPoint(x, y);
         if (!element) {
-          return;
+          return badDrop();
         }
         if (element.nodeType === 3) {
           // Opera
@@ -85,12 +85,21 @@ var $dropProvider = function() {
 
         if (!$droppable) {
           // Element is not droppable...
-          return;
+          return badDrop();
         }
 
         $droppable.drop(current);
 
         return true;
+
+        function badDrop() {
+          current.hanging = true;
+          current.element.css({
+            display: current.cssDisplay
+          });
+          currentDrag = undefined;
+          $rootScope.$emit("$badDrop", current);
+        }
       }
     };
 
@@ -116,6 +125,10 @@ var $dropProvider = function() {
         draggable.element.css({
           display: options.display
         });
+        draggable.hanging = false;
+        if (!$rootScope.$$phase) {
+          $rootScope.$apply();
+        }
         draggable.finish();
       },
     };

--- a/src/provider.js
+++ b/src/provider.js
@@ -1,14 +1,13 @@
 'use strict';
 
 var $dndProvider = function() {
-  this.$get = ['$drag', '$drop', function($drag, $drop) {
-    var currentDrag;
+  this.$get = [function() {
     var $dnd = {
       
     };
 
     // Special read-only properties
-    readonly($dnd, 'current', function() { return $drag.current; });
+    readonly($dnd, 'current', function() { return currentDrag; });
     readonly($dnd, 'version', function() { return _version; });
 
     return $dnd;


### PR DESCRIPTION
There is no test for this as of yet (it is somewhat difficult to test),
but these changes were necessary to make the demo page in issue-3 behave
properly.

The $drag code had gotten a bit mixed up due to experimenting with
implementing Draggable using jQuery-UI's method. The experiment generally
failed and requires far too much extra stuff, so it's been tossed.

This current code gets things generally back in line to where they should
be. We're still relying on pageX/Y rather than clientX/Y now though, however.
