### PR TITLE
chore(karma): use 'dots' reporter

### DIFF
--- a/karma-shared.conf.js
+++ b/karma-shared.conf.js
@@ -6,7 +6,7 @@ module.exports = function(config, specificOptions) {
     logColors: true,
     browsers: ['Firefox', 'PhantomJS'],
     browserDisconnectTimeout: 5000,
-
+    reporters: ['dots'],
 
     // config for Travis CI
     sauceLabs: {


### PR DESCRIPTION
The output on travis looks a bit crazy, 'dots' should clean this up a tad.
