### PR TITLE
feat(gruntfile): add bowerRelease task to publish library on bower

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /bower_components
 /node_modules
 /coverage
+/.bower-release
+/.grunt

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,6 +18,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-conventional-changelog');
   grunt.loadNpmTasks('grunt-ngdocs-caitp');
   grunt.loadNpmTasks('grunt-gh-pages');
+  grunt.loadNpmTasks('grunt-bower-release');
 
   var DROP_VERSION = util.getVersion();
   var dist = 'angular-drop-' + DROP_VERSION.full;
@@ -32,6 +33,26 @@ module.exports = function(grunt) {
     DROP_VERSION: DROP_VERSION,
 
     pkg: pkg,
+
+    bowerRelease: {
+      stable: {
+        options: {
+          endpoint: 'https://github.com/caitp/angular-drop-bower.git',
+          packageName: 'angular-drop',
+          stageDir: '.bower-release/',
+          main: 'angular-drop.min.js',
+          branchName: 'master',
+          dependencies: {}
+        },
+        files: [
+          {
+            expand: true,
+            cwd: 'build/',
+            src: ['angular-drop.js', 'angular-drop.min.js', 'angular-drop.min.js.map']
+          }
+        ]
+      }
+    },
 
     parallel: {
       travis: {
@@ -281,6 +302,8 @@ module.exports = function(grunt) {
     }
     grunt.task.mark().run('gh-pages');
   });
+
+  grunt.registerTask('release', 'Release on bower', ['build', 'bowerRelease']);
 
   return grunt;
 };

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "angular-drop",
+  "version": "0.0.1",
   "authors": [
     "Caitlin Potter <snowball@defpixel.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "karma-jasmine": "~0.1.5",
     "karma-firefox-launcher": "~0.1.3",
     "karma-phantomjs-launcher": "~0.1.1",
-    "karma-coverage": "^0.2.1"
+    "karma-coverage": "^0.2.1",
+    "grunt-bower-release": "0.0.5"
   }
 }


### PR DESCRIPTION
I've created a new repository, http://github.com/caitp/angular-drop-bower,
where the bower release for this project will live. Updating it is automated
via the `grunt release` task, so that should hopefully be nice and easy.

All that remains is to add the new installation instructions to the demo page
and website, horray.

Closes #43
