### PR TITLE
chore(validate-commit-msg): make commit-msg hook suck less

### DIFF
--- a/misc/validate-commit-msg.js
+++ b/misc/validate-commit-msg.js
@@ -13,7 +13,7 @@ var util = require('util');
 
 
 var MAX_LENGTH = 70;
-var PATTERN = /^(?:fixup!\s*)?(\w*)(\((\w+)\))?\: (.*)$/;
+var PATTERN = /^(?:fixup!\s*)?(\w*)(\(((?:\w|[$,.-])+)\))?\: (.*)$/;
 var IGNORED = /^WIP\:/;
 var TYPES = {
   chore: true,


### PR DESCRIPTION
It sucked really bad previously, but now it's marginally better!
